### PR TITLE
Adds land cover code endpoint

### DIFF
--- a/src/api/land/controllers/find-land-code-controller.js
+++ b/src/api/land/controllers/find-land-code-controller.js
@@ -1,0 +1,34 @@
+import Boom from '@hapi/boom'
+import isNull from 'lodash/isNull.js'
+
+import { findLandCoverCode } from '../helpers/find-land-cover-code.js'
+
+/**
+ *
+ * @satisfies {Partial<ServerRoute>}
+ */
+const findLandCoverCodeController = {
+  /**
+   * @param { import('@hapi/hapi').Request & MongoDBPlugin } request
+   * @param { import('@hapi/hapi').ResponseToolkit } h
+   * @returns {Promise<*>}
+   */
+  handler: async (request, h) => {
+    const entity = await findLandCoverCode(
+      request.db,
+      request.params.landCoverCode
+    )
+    if (isNull(entity)) {
+      return Boom.boomify(Boom.notFound())
+    }
+
+    return h.response({ message: 'success', entity }).code(200)
+  }
+}
+
+export { findLandCoverCodeController }
+
+/**
+ * @import { ServerRoute} from '@hapi/hapi'
+ * @import { MongoDBPlugin } from '~/src/helpers/mongodb.js'
+ */

--- a/src/api/land/controllers/index.js
+++ b/src/api/land/controllers/index.js
@@ -1,4 +1,9 @@
 import { findLandParcelController } from './find-land-parcel-controller.js'
 import { findLandCoverController } from './find-land-cover-controller.js'
+import { findLandCoverCodeController } from './find-land-code-controller.js'
 
-export { findLandParcelController, findLandCoverController }
+export {
+  findLandParcelController,
+  findLandCoverController,
+  findLandCoverCodeController
+}

--- a/src/api/land/helpers/find-land-cover-code.js
+++ b/src/api/land/helpers/find-land-cover-code.js
@@ -1,0 +1,38 @@
+const deepSearchPruneUpwards = (data, value) =>
+  data.flatMap((item) => {
+    if (item.code === value) return [{ ...item }]
+
+    const nestedKeys = ['classes', 'covers', 'uses']
+    for (const nestedKey of nestedKeys) {
+      if (item[nestedKey]) {
+        const result = deepSearchPruneUpwards(item[nestedKey], value)
+        if (result.length) return [{ ...item, [nestedKey]: result }]
+      }
+    }
+    return []
+  })
+
+/**
+ * Finds and returns land cover for a single land parcel from ArcGIS.
+ * @param { import('mongodb').Db } db
+ * @param { string } landCoverCode
+ * @returns {Promise<{}|null>}
+ */
+async function findLandCoverCode(db, landCoverCode) {
+  const result = db.collection('land-codes').find(
+    {
+      $or: [
+        { code: landCoverCode.toString() },
+        { 'classes.code': landCoverCode.toString() },
+        { 'classes.covers.code': landCoverCode.toString() },
+        { 'classes.covers.uses.code': landCoverCode.toString() }
+      ]
+    },
+    { projection: { _id: 0 } }
+  )
+
+  const resultArray = await result.toArray()
+  return deepSearchPruneUpwards(resultArray, landCoverCode)
+}
+
+export { findLandCoverCode }

--- a/src/api/land/index.js
+++ b/src/api/land/index.js
@@ -1,6 +1,7 @@
 import {
   findLandParcelController,
-  findLandCoverController
+  findLandCoverController,
+  findLandCoverCodeController
 } from './controllers/index.js'
 
 /**
@@ -20,6 +21,11 @@ const land = {
           method: 'GET',
           path: '/land/cover/{landParcelId}',
           ...findLandCoverController
+        },
+        {
+          method: 'GET',
+          path: '/land/code/{landCoverCode}',
+          ...findLandCoverCodeController
         }
       ])
     }


### PR DESCRIPTION
Adds land cover code endpoint

`/land/code/{landCoverCode}`

The landCoverCode can be any code found within the land codes tree. (class, cover, use)

The response will be an object containing the matched item plus any children - meaning a matched class code could return multiple types of cover, and a matched cover code could return multiple uses